### PR TITLE
Implement unique playlist creation dialog

### DIFF
--- a/script.js
+++ b/script.js
@@ -148,38 +148,77 @@ document.addEventListener('DOMContentLoaded', function() {
             volumeIcon.classList.add('fa-volume-up');
         }
     }
-    // ===== Playlist Drag & Drop Functionality =====
-    const playlists = document.querySelectorAll(".playlists p");
-    const songs = document.querySelectorAll(".song-item, .song-row");
+    // ===== Playlist Handling =====
+    const playlistContainer = document.querySelector('.playlists');
+    const createPlaylistLink = document.querySelector('.playlist-nav a');
+    const songs = document.querySelectorAll('.song-item, .song-row');
 
-    songs.forEach(song => {
-        song.setAttribute("draggable", "true");
-        song.addEventListener("dragstart", function(e) {
-            const title = song.querySelector(".item-title")?.textContent || song.querySelector(".song-name")?.textContent || "";
-            const artist = song.querySelector(".item-subtitle")?.textContent || song.querySelector(".song-artist")?.textContent || "";
-            const img = song.querySelector("img")?.src || "";
-            e.dataTransfer.setData("text/plain", JSON.stringify({title, artist, img}));
-        });
-    });
-
-    playlists.forEach(pl => {
-        pl.addEventListener("dragover", e => e.preventDefault());
-        pl.addEventListener("drop", function(e) {
+    function attachPlaylistEvents(pl) {
+        pl.addEventListener('dragover', e => e.preventDefault());
+        pl.addEventListener('drop', function(e) {
             e.preventDefault();
-            const data = e.dataTransfer.getData("text/plain");
+            const data = e.dataTransfer.getData('text/plain');
             if(!data) return;
             const songData = JSON.parse(data);
             const name = pl.textContent.trim();
-            const key = "playlist_" + name;
-            const list = JSON.parse(localStorage.getItem(key) || "[]");
+            const key = 'playlist_' + name;
+            const list = JSON.parse(localStorage.getItem(key) || '[]');
             list.push(songData);
             localStorage.setItem(key, JSON.stringify(list));
             alert(`Added ${songData.title} to ${name}`);
         });
 
-        pl.addEventListener("click", function() {
+        pl.addEventListener('click', function() {
             const name = pl.textContent.trim();
             window.location.href = `playlist.html?name=${encodeURIComponent(name)}`;
+        });
+    }
+
+    function addPlaylistElement(name) {
+        const p = document.createElement('p');
+        p.textContent = name;
+        playlistContainer.appendChild(p);
+        attachPlaylistEvents(p);
+    }
+
+    if (playlistContainer) {
+        let storedPlaylists = JSON.parse(localStorage.getItem('playlists') || 'null');
+        if (!storedPlaylists) {
+            storedPlaylists = Array.from(playlistContainer.querySelectorAll('p')).map(el => el.textContent.trim());
+            localStorage.setItem('playlists', JSON.stringify(storedPlaylists));
+        } else {
+            playlistContainer.innerHTML = '';
+            storedPlaylists.forEach(name => addPlaylistElement(name));
+        }
+
+        if (createPlaylistLink) {
+            createPlaylistLink.addEventListener('click', function(e) {
+                e.preventDefault();
+                let name = prompt('Enter playlist name:');
+                if (name === null) return;
+                name = name.trim();
+                if (!name) return;
+                const playlists = JSON.parse(localStorage.getItem('playlists') || '[]');
+                if (playlists.some(n => n.toLowerCase() === name.toLowerCase())) {
+                    alert('Playlist name already exists. Please choose a different name.');
+                    return;
+                }
+                playlists.push(name);
+                localStorage.setItem('playlists', JSON.stringify(playlists));
+                addPlaylistElement(name);
+            });
+        }
+    }
+
+    // ===== Playlist Drag & Drop Functionality for songs =====
+
+    songs.forEach(song => {
+        song.setAttribute('draggable', 'true');
+        song.addEventListener('dragstart', function(e) {
+            const title = song.querySelector('.item-title')?.textContent || song.querySelector('.song-name')?.textContent || '';
+            const artist = song.querySelector('.item-subtitle')?.textContent || song.querySelector('.song-artist')?.textContent || '';
+            const img = song.querySelector('img')?.src || '';
+            e.dataTransfer.setData('text/plain', JSON.stringify({title, artist, img}));
         });
     });
 


### PR DESCRIPTION
## Summary
- add a playlist creation feature that prompts for a name
- store playlists in `localStorage` and prevent duplicates
- append new playlists to the navigation list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687776cb4904832e84f6964b4fa6aaaf